### PR TITLE
Implement SHAP explainability

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import src
 from src import __01__preprocessing as preprocess
 from src import __02__modeling as modeling
+from src import __03__explainability as explainability
 
 
 def main():
@@ -9,6 +10,9 @@ def main():
 
     print("Running modeling step...")
     modeling.run_modeling()
+
+    print("Running explainability step...")
+    explainability.run_explainability()
 
     print("All steps completed successfully.")
 

--- a/notebooks/03_explainability.ipynb
+++ b/notebooks/03_explainability.ipynb
@@ -1,15 +1,46 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "93790023",
+   "metadata": {},
+   "source": [
+    "# Explainability\n",
+    "Generate SHAP plots for all models."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "initial_id",
-   "metadata": {
-    "collapsed": true
-   },
+   "id": "e80ec50d",
+   "metadata": {},
    "outputs": [],
    "source": [
-    ""
+    "import pandas as pd\n",
+    "import joblib, shap, matplotlib.pyplot as plt\n",
+    "from pathlib import Path\n",
+    "\n",
+    "train_df = pd.read_csv('../datasets/processed_train.csv')\n",
+    "test_df = pd.read_csv('../datasets/processed_test.csv')\n",
+    "X_train = train_df.drop('target', axis=1)\n",
+    "X_test = test_df.drop('target', axis=1)\n",
+    "base = Path('../outputs')\n",
+    "models = {\n",
+    "    'Logistic Regression': joblib.load(base / 'Logistic Regression' / 'model' / 'logistic_regression_model.pkl'),\n",
+    "    'Random Forest': joblib.load(base / 'Random Forest' / 'model' / 'random_forest_model.pkl'),\n",
+    "    'SVM': joblib.load(base / 'SVM' / 'model' / 'svm_model.pkl'),\n",
+    "}\n",
+    "for name, model in models.items():\n",
+    "    explainer = shap.Explainer(model, X_train)\n",
+    "    shap_values = explainer(X_test)\n",
+    "    plot_dir = base / name / 'plots'\n",
+    "    plot_dir.mkdir(parents=True, exist_ok=True)\n",
+    "    shap.summary_plot(shap_values, X_test, show=False)\n",
+    "    plt.savefig(plot_dir / 'shap_summary.png', bbox_inches='tight')\n",
+    "    plt.close()\n",
+    "    shap.plots.waterfall(shap_values[0], show=False)\n",
+    "    plt.savefig(plot_dir / 'shap_local_0.png', bbox_inches='tight')\n",
+    "    plt.close()\n"
    ]
   }
  ],
@@ -20,15 +51,7 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
    "version": "2.7.6"
   }
  },

--- a/src/__03__explainability.py
+++ b/src/__03__explainability.py
@@ -1,0 +1,78 @@
+import pandas as pd
+import joblib
+import shap
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+
+def run_explainability(index: int = 0) -> None:
+    """Generate SHAP summary and local explanation plots for all models."""
+    print("Loading processed data and models for explainability...")
+
+    train_df = pd.read_csv('datasets/processed_train.csv')
+    test_df = pd.read_csv('datasets/processed_test.csv')
+
+    X_train = train_df.drop('target', axis=1)
+    X_test = test_df.drop('target', axis=1)
+
+    base = Path('outputs')
+    models = {
+        'Logistic Regression': joblib.load(base / 'Logistic Regression' / 'model' / 'logistic_regression_model.pkl'),
+        'Random Forest': joblib.load(base / 'Random Forest' / 'model' / 'random_forest_model.pkl'),
+        'SVM': joblib.load(base / 'SVM' / 'model' / 'svm_model.pkl'),
+    }
+
+    for name, model in models.items():
+        print(f'Explaining {name}...')
+        if name == 'SVM':
+            background = shap.sample(X_train, 50, random_state=42)
+            explainer = shap.KernelExplainer(model.predict_proba, background)
+            shap_values = explainer.shap_values(X_test.iloc[:50])
+            values = shap_values[1] if isinstance(shap_values, list) else shap_values[:, :, 1]
+            sv = shap.Explanation(
+                values=values,
+                base_values=explainer.expected_value[1],
+                data=X_test.iloc[:50].values,
+                feature_names=X_test.columns,
+            )
+        else:
+            explainer = shap.Explainer(model, X_train)
+            if hasattr(explainer, 'model') and hasattr(explainer.model, 'output_type') and explainer.model.output_type == 'probability':
+                shap_values = explainer(X_test, check_additivity=False)
+            else:
+                shap_values = explainer(X_test)
+            if len(shap_values.shape) == 3:
+                sv = shap.Explanation(
+                    values=shap_values.values[:, :, 1],
+                    base_values=shap_values.base_values[:, 1],
+                    data=shap_values.data,
+                    feature_names=shap_values.feature_names,
+                )
+            else:
+                sv = shap_values
+
+        plot_dir = base / name / 'plots'
+        plot_dir.mkdir(parents=True, exist_ok=True)
+
+        summary_path = plot_dir / 'shap_summary.png'
+        features = X_test.iloc[:sv.shape[0]] if not isinstance(sv, shap._explanation.Explanation) else X_test.iloc[:len(sv)]
+        shap.summary_plot(sv, features=features, show=False)
+        plt.tight_layout()
+        plt.savefig(summary_path, bbox_inches='tight')
+        plt.close()
+
+        local_path = plot_dir / f'shap_local_{index}.png'
+        if isinstance(sv, shap._explanation.Explanation):
+            shap.plots.waterfall(sv[min(index, len(sv)-1)], show=False)
+        else:
+            exp = shap.Explanation(
+                values=sv[min(index, sv.shape[0]-1)],
+                base_values=explainer.expected_value[1] if name == 'SVM' else explainer.expected_value,
+                data=X_test.iloc[min(index, len(X_test)-1)].values,
+                feature_names=X_test.columns,
+            )
+            shap.plots.waterfall(exp, show=False)
+        plt.savefig(local_path, bbox_inches='tight')
+        plt.close()
+
+        print(f'SHAP plots saved to {plot_dir}/')


### PR DESCRIPTION
## Summary
- fill in explainability notebook with SHAP steps
- implement `run_explainability` with SHAP plots for all models
- call explainability step from `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from src import __01__preprocessing as preprocess
from src import __02__modeling as modeling
from src import __03__explainability as explain

preprocess.run_preprocessing()
modeling.run_modeling()
explain.run_explainability(index=0)
print('Done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_686de635c790832a87c8fb5dd2e76754